### PR TITLE
Fix PYTHONTRACEMALLOC env var behavior

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -369,8 +369,6 @@ read `tracemalloc module documentation
 There are differences between the third party pytracemalloc module (downloaded
 from PyPI) and the tracemalloc which is part of the Python standard library:
 
-* stdlib tracemalloc supports a ``PYTHONTRACEMALLOC`` environment variable
-  to start tracing at Python startup.
 * stdlib tracemalloc supports a ``-X tracemalloc=NFRAMES`` command line option
   to start tracing at Python startup.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,14 +17,12 @@ Python. It provides the following information:
   total size, number and average size of allocated memory blocks
 * Compute the differences between two snapshots to detect memory leaks
 
-To trace most memory blocks allocated by Python, the module should be started
-as early as possible by setting the :envvar:`PYTHONTRACEMALLOC` environment
-variable to ``1``. The :func:`tracemalloc.start` function can be called at runtime to
-start tracing Python memory allocations.
+The :func:`tracemalloc.start` function can be called at runtime to start 
+tracing Python memory allocations. To trace most memory blocks allocated by
+Python, it should be called as soon as possible.
 
 By default, a trace of an allocated memory block only stores the most recent
-frame (1 frame). To store 25 frames at startup: set the
-:envvar:`PYTHONTRACEMALLOC` environment variable to ``25``.
+frame (1 frame). To store 25 frames, use ``tracemalloc.start(25)``.
 
 Websites:
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,12 +17,15 @@ Python. It provides the following information:
   total size, number and average size of allocated memory blocks
 * Compute the differences between two snapshots to detect memory leaks
 
-The :func:`tracemalloc.start` function can be called at runtime to start 
-tracing Python memory allocations. To trace most memory blocks allocated by
-Python, it should be called as soon as possible.
+To trace most memory blocks allocated by Python, the module should be started
+as early as possible by setting the :envvar:`PYTHONTRACEMALLOC` environment
+variable to ``1``. The :func:`tracemalloc.start` function can be called at runtime to
+start tracing Python memory allocations.
 
 By default, a trace of an allocated memory block only stores the most recent
-frame (1 frame). To store 25 frames, use ``tracemalloc.start(25)``.
+frame (1 frame). To store 25 frames at startup: set the
+:envvar:`PYTHONTRACEMALLOC` environment variable to ``25``, or use 
+``tracemalloc.start(25)``.
 
 Websites:
 

--- a/patches/2.6/files/Python/pythonrun.c
+++ b/patches/2.6/files/Python/pythonrun.c
@@ -293,10 +293,10 @@ Py_InitializeEx(int install_sigs)
     _PyGILState_Init(interp, tstate);
 #endif /* WITH_THREAD */
 
-    inittracemalloc();
-
     if (!Py_NoSiteFlag)
         initsite(); /* Module site */
+
+    inittracemalloc();
 
     if ((p = Py_GETENV("PYTHONIOENCODING")) && *p != '\0') {
         p = icodeset = codeset = strdup(p);

--- a/patches/2.6/pep445.patch
+++ b/patches/2.6/pep445.patch
@@ -1004,13 +1004,12 @@ diff -r afe43d4c7ac2 -r 9b3082bc0cb8 Python/pythonrun.c
  void
  Py_InitializeEx(int install_sigs)
  {
-@@ -258,6 +293,8 @@ Py_InitializeEx(int install_sigs)
-     _PyGILState_Init(interp, tstate);
- #endif /* WITH_THREAD */
- 
-+    inittracemalloc();
-+
+@@ -261,6 +296,8 @@ Py_InitializeEx(int install_sigs)
      if (!Py_NoSiteFlag)
          initsite(); /* Module site */
  
-
++    inittracemalloc();
++
+     if ((p = Py_GETENV("PYTHONIOENCODING")) && *p != '\0') {
+         p = icodeset = codeset = strdup(p);
+         free_codeset = 1;

--- a/patches/2.7.10/2.7/files/Python/pythonrun.c
+++ b/patches/2.7.10/2.7/files/Python/pythonrun.c
@@ -301,10 +301,10 @@ Py_InitializeEx(int install_sigs)
     _PyGILState_Init(interp, tstate);
 #endif /* WITH_THREAD */
 
-    inittracemalloc();
-
     if (!Py_NoSiteFlag)
         initsite(); /* Module site */
+
+    inittracemalloc();
 
     if ((p = Py_GETENV("PYTHONIOENCODING")) && *p != '\0') {
         p = icodeset = codeset = strdup(p);

--- a/patches/2.7.10/2.7/pep445.patch
+++ b/patches/2.7.10/2.7/pep445.patch
@@ -922,12 +922,12 @@ diff -r 15c95b7d81dc Python/pythonrun.c
  void
  Py_InitializeEx(int install_sigs)
  {
-@@ -266,6 +301,8 @@
-     _PyGILState_Init(interp, tstate);
- #endif /* WITH_THREAD */
- 
-+    inittracemalloc();
-+
+@@ -269,6 +304,8 @@ Py_InitializeEx(int install_sigs)
      if (!Py_NoSiteFlag)
          initsite(); /* Module site */
  
++    inittracemalloc();
++
+     if ((p = Py_GETENV("PYTHONIOENCODING")) && *p != '\0') {
+         p = icodeset = codeset = strdup(p);
+         free_codeset = 1;

--- a/patches/2.7.12/2.7/pep445.patch
+++ b/patches/2.7.12/2.7/pep445.patch
@@ -927,15 +927,16 @@ index 7b85268c63..858205cbf2 100644
  void
  Py_InitializeEx(int install_sigs)
  {
-@@ -280,6 +315,8 @@ Py_InitializeEx(int install_sigs)
-     _PyGILState_Init(interp, tstate);
- #endif /* WITH_THREAD */
- 
-+    inittracemalloc();
-+
+@@ -283,6 +318,8 @@ Py_InitializeEx(int install_sigs)
      if (!Py_NoSiteFlag)
          initsite(); /* Module site */
  
++    inittracemalloc();
++
+     if ((p = Py_GETENV("PYTHONIOENCODING")) && *p != '\0') {
+         p = icodeset = codeset = strdup(p);
+         free_codeset = 1;
+
 -- 
 2.14.1
 

--- a/patches/2.7/files/Python/pythonrun.c
+++ b/patches/2.7/files/Python/pythonrun.c
@@ -301,10 +301,10 @@ Py_InitializeEx(int install_sigs)
     _PyGILState_Init(interp, tstate);
 #endif /* WITH_THREAD */
 
-    inittracemalloc();
-
     if (!Py_NoSiteFlag)
         initsite(); /* Module site */
+
+    inittracemalloc();
 
     if ((p = Py_GETENV("PYTHONIOENCODING")) && *p != '\0') {
         p = icodeset = codeset = strdup(p);

--- a/patches/2.7/pep445.patch
+++ b/patches/2.7/pep445.patch
@@ -919,12 +919,12 @@ diff -r bf5576b8c41d Python/pythonrun.c
  void
  Py_InitializeEx(int install_sigs)
  {
-@@ -266,6 +301,8 @@ Py_InitializeEx(int install_sigs)
-     _PyGILState_Init(interp, tstate);
- #endif /* WITH_THREAD */
- 
-+    inittracemalloc();
-+
+@@ -269,6 +304,8 @@ Py_InitializeEx(int install_sigs)
      if (!Py_NoSiteFlag)
          initsite(); /* Module site */
  
++    inittracemalloc();
++
+     if ((p = Py_GETENV("PYTHONIOENCODING")) && *p != '\0') {
+         p = icodeset = codeset = strdup(p);
+         free_codeset = 1;

--- a/patches/3.3/files/Python/pythonrun.c
+++ b/patches/3.3/files/Python/pythonrun.c
@@ -429,10 +429,10 @@ _Py_InitializeEx_Private(int install_sigs, int install_importlib)
         Py_XDECREF(warnings_module);
     }
 
-    inittracemalloc();
-
     if (!Py_NoSiteFlag)
         initsite(); /* Module site */
+
+    inittracemalloc();
 }
 
 void

--- a/patches/3.3/pep445.patch
+++ b/patches/3.3/pep445.patch
@@ -889,12 +889,12 @@ diff -r 0abe369829a3 Python/pythonrun.c
  
  void
  _Py_InitializeEx_Private(int install_sigs, int install_importlib)
-@@ -395,6 +429,8 @@ void
-         Py_XDECREF(warnings_module);
-     }
+@@ -397,6 +431,8 @@ _Py_InitializeEx_Private(int install_sig
  
-+    inittracemalloc();
-+
      if (!Py_NoSiteFlag)
          initsite(); /* Module site */
++
++    inittracemalloc();
  }
+ 
+ void

--- a/test_patch.sh
+++ b/test_patch.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+declare -a python_urls=(
+"https://www.python.org/ftp/python/2.6.9/Python-2.6.9.tgz" 
+"https://www.python.org/ftp/python/2.7.9/Python-2.7.9.tgz" 
+"https://www.python.org/ftp/python/2.7.10/Python-2.7.10.tgz" 
+"https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tgz" 
+"https://www.python.org/ftp/python/3.3.7/Python-3.3.7.tgz" 
+)
+declare -a patches=( 
+"patches/2.6/pep445.patch" 
+"patches/2.7/pep445.patch" 
+"patches/2.7.10/2.7/pep445.patch" 
+"patches/2.7.12/2.7/pep445.patch" 
+"patches/3.3/pep445.patch" 
+)
+src=$(dirname "$BASH_SOURCE")
+test_py_file="test_tracemalloc_env_var.py"
+
+for i in "${!python_urls[@]}"; do 
+    rm -rf /tmp/test-pytracemalloc-patch
+    mkdir -p /tmp/test-pytracemalloc-patch
+    cd /tmp/test-pytracemalloc-patch
+    python_url="${python_urls[$i]}"
+    patch_path="${src}/${patches[$i]}"
+    printf "%s\t%s\n" "${patch_path}" "${python_url}"
+    
+    # Download Python source
+    wget -O python.tgz "${python_url}"
+    tar -xf python.tgz
+    cd $(ls -d */|head -n 1)
+    
+    # Patch and compile
+    patch -p1 < "${patch_path}"
+    ./configure --enable-unicode=ucs4 --prefix=/tmp/test-pytracemalloc-patch/py
+    make install
+    
+    cd ${src}
+    py="/tmp/test-pytracemalloc-patch/py/bin/python"
+    if [ ! -f "${py}" ]
+    then
+        py="/tmp/test-pytracemalloc-patch/py/bin/python3"
+    fi
+    ${py} setup.py install
+    PYTHONTRACEMALLOC=1 ${py} "${test_py_file}"
+    printf "%s\t%s OK\n" "${patch_path}" "${python_url}"
+done
+
+rm -rf /tmp/test-pytracemalloc-patch

--- a/test_tracemalloc_env_var.py
+++ b/test_tracemalloc_env_var.py
@@ -1,0 +1,6 @@
+import tracemalloc
+
+# allocate some memory
+x = range(10000)
+
+snapshot = tracemalloc.take_snapshot()


### PR DESCRIPTION
Document `tracemalloc.start` `nframe` argument usage as noted in API page.