### PR TITLE
Update install.rst pytracemalloc version in patch example

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -67,7 +67,7 @@ To install pytracemalloc, you need a modified Python runtime:
 * Uncompress the tarball and enter the newly created directory (ex: Python-2.7.8)
 * Apply the patch of your Python version, example::
 
-    patch -p1 < ~/pytracemalloc-1.0/patches/2.7/pep445.patch
+    patch -p1 < ~/pytracemalloc-1.4/patches/2.7/pep445.patch
 
 * Compile and install Python::
 


### PR DESCRIPTION
I updated the docs to reflect the version of pytracemalloc in the example above it.  Just looks like someone missed a reference to it when periodically updating docs?

It threw me off initially so I thought it might help someone else!